### PR TITLE
Track progress of fetching models

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = "*"
 dirs = "*"
 itertools = "*"
 ehttp = { version = "0.4", features = ["native-async"] }
+crossbeam-channel = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,8 @@ edition = "2021"
 
 [dependencies]
 futures-lite = "*"
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 serde_json = "*"
 dirs = "*"
 itertools = "*"
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-surf = { version = "2.3", default-features = false, features = ["wasm-client", "encoding"] }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-surf = { version = "2.3" }
+ehttp = { version = "0.4", features = ["native-async"] }

--- a/src/fuel_client.rs
+++ b/src/fuel_client.rs
@@ -1,9 +1,12 @@
 use futures_lite::future;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use std::fs;
-use std::path::PathBuf;
-use std::time::{Duration, SystemTime};
+use std::{
+    fs,
+    path::PathBuf,
+    time::{Duration, SystemTime},
+    sync::mpsc::Sender,
+};
 
 // TODO(luca) clone can be unsafe if two instances try to write to the same file
 #[derive(Clone)]
@@ -37,7 +40,10 @@ impl FuelClient {
         self
     }
 
-    async fn build_cache(&self) -> Option<Vec<FuelModel>> {
+    async fn build_cache(
+        &self,
+        progress: Option<Sender<FuelModel>>,
+    ) -> Option<Vec<FuelModel>> {
         let mut page = 1;
         let mut models = Vec::new();
         let models = loop {
@@ -54,6 +60,11 @@ impl FuelClient {
             let Ok(mut fetched_models) = serde_json::de::from_str::<Vec<FuelModel>>(&res) else {
                 break models;
             };
+            if let Some(progress) = &progress {
+                for model in &fetched_models {
+                    progress.send(model.clone()).ok();
+                }
+            }
             models.append(&mut fetched_models);
             page += 1;
         };
@@ -95,7 +106,15 @@ impl FuelClient {
 
     /// Returns Some if cache writing was successful, None otherwise
     pub async fn update_cache(&mut self, write_to_disk: bool) -> Option<Vec<FuelModel>> {
-        if let Some(models) = self.build_cache().await {
+        self.update_cache_with_progress(write_to_disk, None).await
+    }
+
+    pub async fn update_cache_with_progress(
+        &mut self,
+        write_to_disk: bool,
+        progress: Option<Sender<FuelModel>>,
+    ) -> Option<Vec<FuelModel>> {
+        if let Some(models) = self.build_cache(progress).await {
             self.models = Some(models);
             if write_to_disk {
                 let path = self.cache_path.clone().or_else(Self::default_cache_path)?;

--- a/src/fuel_client.rs
+++ b/src/fuel_client.rs
@@ -47,7 +47,7 @@ impl FuelClient {
         let mut page = 1;
         let mut models = Vec::new();
         let models = loop {
-            let url = self.url.clone() + "models" + "?page=" + &page.to_string();
+            let url = format!("{}models?page={page}&per_page=100", self.url);
             let mut req = ehttp::Request::get(url.clone());
             if let Some(token) = &self.token {
                 req.headers

--- a/src/fuel_client.rs
+++ b/src/fuel_client.rs
@@ -5,8 +5,8 @@ use std::{
     fs,
     path::PathBuf,
     time::{Duration, SystemTime},
-    sync::mpsc::Sender,
 };
+use crossbeam_channel::Sender;
 
 // TODO(luca) clone can be unsafe if two instances try to write to the same file
 #[derive(Clone)]

--- a/src/fuel_client.rs
+++ b/src/fuel_client.rs
@@ -42,13 +42,17 @@ impl FuelClient {
         let mut models = Vec::new();
         let models = loop {
             let url = self.url.clone() + "models" + "?page=" + &page.to_string();
-            let mut req = surf::get(url.clone());
+            let mut req = ehttp::Request::get(url.clone());
             if let Some(token) = &self.token {
-                req = req.header("Private-token", token.clone());
+                req.headers
+                    .headers
+                    .push(("Private-token".to_owned(), token.clone()));
             }
-            let Ok(res) = req
-                .recv_string()
-                .await else {
+            let Some(res) = ehttp::fetch_async(req)
+                .await
+                .ok()
+                .and_then(|res| String::from_utf8(res.bytes).ok())
+            else {
                 break models;
             };
             let Ok(mut fetched_models) = serde_json::de::from_str::<Vec<FuelModel>>(&res) else {


### PR DESCRIPTION
When the fuel download client was running in the site editor, I felt somewhat out in the cold while the download was allegedly happening without any indication of what progress was being made.

This PR adds a hook for streaming out information about what models are being fetched. In the refactoring of the site editor UI, I'm using this to give live updates about what models have been received.

I also opened ticket #3 which I think would be the final piece in truly making this a top-notch fuel client.